### PR TITLE
Recommend podman over Docker for Linux environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Setting up Rails for the first time with all the dependencies necessary can be d
 To use Docked Rails, follow these steps on macOS:
 
 1. [Install Docker](https://www.docker.com/products/docker-desktop/)
-1. Copy'n'paste to run in terminal: 
+1. Copy'n'paste to run in terminal:
    ```bash
    docker volume create ruby-bundle-cache
    alias rails='docker run --rm -it -v ${PWD}:/rails -v ruby-bundle-cache:/bundle dhh37/rails'
@@ -16,8 +16,8 @@ To use Docked Rails, follow these steps on macOS:
 
 Or on Linux 64-bit:
 
-1. [Install Docker](https://www.docker.com/products/docker-desktop/)
-1. Copy'n'paste to run in terminal: 
+1. [Install Podman](https://podman.io/getting-started/installation) and `alias docker=podman`, or [Install Docker](https://www.docker.com/products/docker-desktop/)
+1. Copy'n'paste to run in terminal:
    ```bash
    docker volume create ruby-bundle-cache
    alias rails='docker run --rm -it -v ${PWD}:/rails -v ruby-bundle-cache:/bundle dhh37/rails-amd64'
@@ -28,7 +28,7 @@ Or on Windows (with PowerShell):
 
 1. [Install WSL](https://learn.microsoft.com/en-us/windows/wsl/install)
 1. [Install Docker](https://www.docker.com/products/docker-desktop/)
-1. Copy'n'paste to run in terminal: 
+1. Copy'n'paste to run in terminal:
    ```bash
    docker volume create ruby-bundle-cache
    alias rails='docker run --rm -it -v ${PWD}:/rails -v ruby-bundle-cache:/bundle dhh37/rails-amd64'


### PR DESCRIPTION
[Podman](https://podman.io/) is a well known container engine and popular alternative to Docker, maintained by the container organization.

It features a Docker-compatible interface (same commands and arguments) but runs on a user-level. It does not require root access as Docker does.

Podman is preinstalled on several Linux distributions (e.g. Fedora) and does not require an additional setup.