### PR TITLE
Allow default entrypoint to receive arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ VOLUME /bundle
 RUN gem install bundler && bundle config set --global path '/bundle'
 RUN gem install rails
 
-ENTRYPOINT rails
+ENTRYPOINT ["rails"]


### PR DESCRIPTION
Whilst trying to run this locally under Fedora I hit issues passing additional arguments when invoking using the default entry point as set in the Dockerfile:

```sh
$ which rails
rails: aliased to docker run --rm -it -v ${PWD}:/rails -v ruby-bundle-cache:/bundle ghcr.io/rails/cli

$ docker inspect -f '{{.Config.Entrypoint}}' ghcr.io/rails/cli
[/bin/sh -c rails]

$ rails -v                                                    
Usage:
  rails new APP_PATH [options]
...
```

As per the Dockerfile reference the shell form of the `ENTRYPOINT` "[prevents any CMD or run command line arguments from being used](https://docs.docker.com/engine/reference/builder/#entrypoint)"

Swapping the ENTRYPOINT to exec mode allows us to accept additional command line arguments passed via docker run:

```sh
$ which rails
rails: aliased to docker run --rm -it -v ${PWD}:/rails -v ruby-bundle-cache:/bundle docked

$ docker inspect -f '{{.Config.Entrypoint}}' docked
[rails]

$ rails -v
Rails 7.0.4
```