### PR TITLE
Use ruby alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,11 @@ COPY --from=node /usr/local/share /usr/local/share
 COPY --from=node /usr/local/lib /usr/local/lib
 COPY --from=node /usr/local/include /usr/local/include
 COPY --from=node /usr/local/bin /usr/local/bin
+COPY --from=node /opt/yarn* /opt/yarn/
+
+RUN rm /usr/local/bin/yarn /usr/local/bin/yarnpkg \
+    && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
+    && ln -s /opt/yarn/bin/yarnpkg /usr/local/bin/yarnpkg
 
 # Ensure binding is always 0.0.0.0, even in development, to access server from outside container
 ENV BINDING="0.0.0.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
-FROM ruby:3.1
+ARG RUBY_VERSION=3.1
+ARG NODE_VERSION=19
 
-# Ensure node.js 19 is available for apt-get
-RUN curl -sL https://deb.nodesource.com/setup_19.x | bash -
+FROM node:${NODE_VERSION}-alpine AS node
+
+FROM ruby:${RUBY_VERSION}-alpine
 
 # Install dependencies
-RUN apt-get update -qq && apt-get install -y build-essential libvips nodejs && npm install -g yarn
+RUN apk --no-cache add \
+      build-base \
+      git \
+      libressl-dev \
+      libxml2-dev \
+      tzdata
 
 # Mount $PWD to this workdir
 WORKDIR /rails
@@ -16,6 +23,13 @@ ENV PATH="/bundle/ruby/3.1.0/bin:${PATH}"
 
 # Install Rails
 RUN gem install rails
+
+# Copy node binaries
+COPY --from=node /usr/lib /usr/lib
+COPY --from=node /usr/local/share /usr/local/share
+COPY --from=node /usr/local/lib /usr/local/lib
+COPY --from=node /usr/local/include /usr/local/include
+COPY --from=node /usr/local/bin /usr/local/bin
 
 # Ensure binding is always 0.0.0.0, even in development, to access server from outside container
 ENV BINDING="0.0.0.0"


### PR DESCRIPTION
I believe the dependencies added are the least required by Rails and Puma.
- `build-base` for compiling gems using native extensions
- `git` is required when running `rails new`
- `libressl-dev` is required by Puma, in case you bind SSL certificates directly
- `libxml2-dev` is for XML parser. Like nokogiri.
- `tzdata` Timezone

The new Dockerfile will reduce the final image to about 550MB, uncompressed.
![image](https://user-images.githubusercontent.com/1308495/208670369-64015b07-8e06-48e8-9771-4aa081948a66.png)

### Changes
- Adds build arguments: `RUBY_VERSION` (defaults: 3.1) and `NODE_VERSION` (defaults: 19)
- Use ruby alpine as base image. 
- Use multistage build to pull in binaries from node without having to reinstall node.

Contributes to #10 