### PR TITLE
Change to Fullstaq Ruby Docker Images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,18 @@
-FROM ruby:3.2
+ARG RUBY_VERSION=3.2.0
+ARG VARIANT=jemalloc-bullseye-slim
+FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-${VARIANT} as base
 
 # Ensure node.js 19 is available for apt-get
 RUN curl -sL https://deb.nodesource.com/setup_19.x | bash -
 
 # Install dependencies
-RUN apt-get update -qq && apt-get install -y build-essential libvips nodejs && npm install -g yarn
+RUN apt-get update -qq \
+  && apt-get install -qq -y build-essential libvips nodejs \
+  && apt-get upgrade -qq \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists \
+  && rm -rf /var/cache/apt \
+  && npm install -g yarn
 
 # Mount $PWD to this workdir
 WORKDIR /rails
@@ -13,6 +21,7 @@ WORKDIR /rails
 VOLUME /bundle
 RUN bundle config set --global path '/bundle'
 ENV PATH="/bundle/ruby/3.2.0/bin:${PATH}"
+ENV RUBY_YJIT_ENABLE true
 
 # Install Rails
 RUN gem install rails


### PR DESCRIPTION
One of the issues of the main  `ruby` image is that they do not ship with `rust` dependency for enabling `yjit`. After digging on the internet I found the [Fullstaq Ruby Docker images](https://github.com/evilmartians/fullstaq-ruby-docker) which is a cool project from Evil Martians that provides an MRI-based Ruby distribution that's optimized for server production use cases. It is compiled with the [Jemalloc](https://medium.com/rubyinside/how-we-halved-our-memory-consumption-in-rails-with-jemalloc-86afa4e54aa3) and [malloc_trim](https://www.joyfulbikeshedding.com/blog/2019-03-14-what-causes-ruby-memory-bloat.html) patches, allowing lower memory usage and higher performance.

Edit: @eileencodes mentions another Docker image from `rubylang` repository on her [presentation at RubyConf](https://youtu.be/PBEklhwJcUA?list=PLbHJudTY1K0dERpqJUEFOFSsMGvR6st9U&t=572).