### PR TITLE
build: use latest Node LTS version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM ruby:$RUBY_VERSION-slim
 # Install dependencies
 RUN apt-get update -qq && apt-get install -y build-essential libvips gnupg2 curl git
 
-# Ensure node.js 19 is available for apt-get
-ARG NODE_MAJOR=19
+# Ensure node.js 18 is available for apt-get
+ARG NODE_MAJOR=18
 RUN curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash -
 
 # Install node and yarn


### PR DESCRIPTION
The latest Node major version might be a moving target for support. The long-term support version should be better and necessitate fewer changes over time. 

https://github.com/nodejs/release#release-schedule