### PR TITLE
Suggest using the host network mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Install [Docker](https://www.docker.com/products/docker-desktop/) (and [WSL](htt
 
 ```bash
 docker volume create ruby-bundle-cache
-alias docked='docker run --rm -it -v ${PWD}:/rails -u $(id -u):$(id -g) -v ruby-bundle-cache:/bundle -p 3000:3000 ghcr.io/rails/cli'
+alias docked='docker run --rm -it -v ${PWD}:/rails -u $(id -u):$(id -g) -v ruby-bundle-cache:/bundle --network host ghcr.io/rails/cli'
 ```
 
 Then create your Rails app:


### PR DESCRIPTION
Using the host networking guarantees that running mutliple container won't cause port conflicts.

It also enables easily changing the port via `-p <PORT>` which is not possible when binding port 3000 only.

Could resolve #18