### PR TITLE
Use `rails` as the entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,5 @@ ENV PATH="/bundle/ruby/$RUBY_VERSION/bin:${PATH}"
 # Install Rails
 RUN gem install rails
 
-# Ensure binding is always 0.0.0.0, even in development, to access server from outside container
-ENV BINDING="0.0.0.0"
-
 # Overwrite ruby image's entrypoint to provide open cli
-ENTRYPOINT [""]
+ENTRYPOINT ["rails"]

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ alias docked='docker run --rm -it -v ${PWD}:/rails -u $(id -u):$(id -g) -v ruby-
 Then create your Rails app:
 
 ```bash
-docked rails new weblog
+docked new weblog
 cd weblog
-docked rails generate scaffold post title:string body:text
-docked rails db:migrate
-docked rails server
+docked generate scaffold post title:string body:text
+docked db:migrate
+docked server
 ```
 
 That's it! Your Rails app is running on `http://localhost:3000/posts`.


### PR DESCRIPTION
Suggestion to add `rails` as the container `ENTRYPOINT` which enables a more streamlined experience by not requiring the user to type in `rails` after `docked`.

I'm wondering if this could be pushed further by renaming the alias something like `drails` (docked-rails) to highlight the fact that it's running Rails.
One could go even further and naming the alias `rails` but I think it would cause issues and confusion with potential native rails installations.
