### PR TITLE
Use Ruby 3.4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG RUBY_VERSION=3.3.0
+ARG RUBY_VERSION=3.4.4
 
 FROM ruby:$RUBY_VERSION-slim
 
 # Install dependencies
-RUN apt-get update -qq && apt-get install -y build-essential libvips gnupg2 curl git
+RUN apt-get update -qq && apt-get install -y build-essential libvips gnupg2 curl git libyaml-dev
 
 # Ensure node.js 20 is available for apt-get
 ARG NODE_MAJOR=20


### PR DESCRIPTION
When using Ruby 3.3.0 to generate a project with `--devcontainer`, it will encounter an error when building the container.

It is a known issue https://github.com/ruby-concurrency/concurrent-ruby/issues/1020

Updated to 3.4.4 to fix this issue. Also added the missing dependency libyaml-dev.

Error message:

```
== Preparing database ==
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomic/lock_local_var.rb:14: [BUG] Segmentation fault at 0x0079ffff92ade6c0
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [aarch64-linux]

-- Control frame information -----------------------------------------------
c:0100 p:---- s:0547 e:000546 CFUNC  :resume
c:0099 p:0007 s:0543 E:000d70 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomic/lock_lo [FINISH]
c:0098 p:---- s:0540 e:000539 CFUNC  :synchronize
c:0097 p:0026 s:0536 E:000598 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomic/lock_lo
c:0096 p:0007 s:0531 e:000530 CLASS  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomic/lock_lo
c:0095 p:0025 s:0528 e:000527 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomic/lock_lo [FINISH]
c:0094 p:---- s:0525 e:000524 CFUNC  :require
c:0093 p:0030 s:0520 e:000519 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0092 p:0131 s:0514 e:000513 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0091 p:0041 s:0505 e:000504 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomic/reentra [FINISH]
c:0090 p:---- s:0502 e:000501 CFUNC  :require
c:0089 p:0030 s:0497 e:000496 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0088 p:0131 s:0491 e:000490 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0087 p:0047 s:0482 e:000481 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomics.rb:8 [FINISH]
c:0086 p:---- s:0479 e:000478 CFUNC  :require
c:0085 p:0030 s:0474 e:000473 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0084 p:0131 s:0468 e:000467 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0083 p:0029 s:0459 e:000458 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent.rb:6 [FINISH]
c:0082 p:---- s:0456 e:000455 CFUNC  :require
c:0081 p:0030 s:0451 e:000450 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0080 p:0131 s:0445 e:000444 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0079 p:0005 s:0436 e:000435 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/tzinfo-2.0.6/lib/tzinfo/string_deduper.rb:4 [FINISH]
c:0078 p:---- s:0433 e:000432 CFUNC  :require_relative
c:0077 p:0025 s:0428 e:000427 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/tzinfo-2.0.6/lib/tzinfo.rb:25 [FINISH]
c:0076 p:---- s:0425 e:000424 CFUNC  :require
c:0075 p:0030 s:0420 e:000419 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0074 p:0131 s:0414 e:000413 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0073 p:0005 s:0405 e:000404 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/values/time_zone.rb:3 [FINISH]
c:0072 p:---- s:0402 e:000401 CFUNC  :require
c:0071 p:0030 s:0397 e:000396 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0070 p:0131 s:0391 e:000390 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0069 p:0017 s:0382 e:000381 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/core_ext/time/conversions.rb [FINISH]
c:0068 p:---- s:0379 e:000378 CFUNC  :require
c:0067 p:0030 s:0374 e:000373 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0066 p:0131 s:0368 e:000367 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0065 p:0065 s:0359 e:000358 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/core_ext/object/json.rb:14 [FINISH]
c:0064 p:---- s:0356 e:000355 CFUNC  :require
c:0063 p:0030 s:0351 e:000350 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0062 p:0131 s:0345 e:000344 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0061 p:0005 s:0336 e:000335 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/json/encoding.rb:3 [FINISH]
c:0060 p:---- s:0333 e:000332 CFUNC  :require
c:0059 p:0030 s:0328 e:000327 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0058 p:0131 s:0322 e:000321 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0057 p:0011 s:0313 e:000312 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/json.rb:4 [FINISH]
c:0056 p:---- s:0310 e:000309 CFUNC  :require
c:0055 p:0030 s:0305 e:000304 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0054 p:0131 s:0299 e:000298 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0053 p:0011 s:0290 e:000289 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/messages/metadata.rb:4 [FINISH]
c:0052 p:---- s:0287 e:000286 CFUNC  :require_relative
c:0051 p:0011 s:0282 e:000281 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/messages/codec.rb:4 [FINISH]
c:0050 p:---- s:0279 e:000278 CFUNC  :require
c:0049 p:0030 s:0274 e:000273 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0048 p:0131 s:0268 e:000267 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0047 p:0023 s:0259 e:000258 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/message_encryptor.rb:6 [FINISH]
c:0046 p:---- s:0256 e:000255 CFUNC  :require
c:0045 p:0030 s:0251 e:000250 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0044 p:0131 s:0245 e:000244 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0043 p:0017 s:0236 e:000235 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/encrypted_file.rb:5 [FINISH]
c:0042 p:---- s:0233 e:000232 CFUNC  :require
c:0041 p:0030 s:0228 e:000227 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0040 p:0131 s:0222 e:000221 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0039 p:0011 s:0213 e:000212 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/encrypted_configuration.rb:4 [FINISH]
c:0038 p:---- s:0210 e:000209 CFUNC  :require
c:0037 p:0030 s:0205 e:000204 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0036 p:0131 s:0199 e:000198 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0035 p:0041 s:0190 e:000189 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/application.rb:9 [FINISH]
c:0034 p:---- s:0187 e:000186 CFUNC  :require
c:0033 p:0030 s:0182 e:000181 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0032 p:0131 s:0176 e:000175 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0031 p:0053 s:0167 e:000166 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails.rb:13 [FINISH]
c:0030 p:---- s:0164 e:000163 CFUNC  :require
c:0029 p:0030 s:0159 e:000158 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0028 p:0131 s:0153 e:000152 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0027 p:0005 s:0144 e:000143 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/all.rb:3 [FINISH]
c:0026 p:---- s:0141 e:000140 CFUNC  :require
c:0025 p:0030 s:0136 e:000135 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0024 p:0131 s:0130 e:000129 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0023 p:0011 s:0121 e:000120 TOP    /workspaces/foobar/config/application.rb:3 [FINISH]
c:0022 p:---- s:0118 e:000117 CFUNC  :require_relative
c:0021 p:0005 s:0113 e:000112 TOP    /workspaces/foobar/rakefile:4 [FINISH]
c:0020 p:---- s:0110 e:000109 CFUNC  :load
c:0019 p:0005 s:0105 e:000104 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_module.rb:29
c:0018 p:0143 s:0100 e:000099 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:740
c:0017 p:0003 s:0094 e:000093 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:126
c:0016 p:0002 s:0091 e:000090 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:214
c:0015 p:0004 s:0086 e:000085 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:125
c:0014 p:0021 s:0082 e:000081 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/commands/rake/rake_command.rb:43
c:0013 p:0023 s:0078 e:000077 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_module.rb:59
c:0012 p:0021 s:0072 e:000071 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/commands/rake/rake_command.rb:41
c:0011 p:0010 s:0065 e:000064 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/commands/rake/rake_command.rb:20
c:0010 p:0032 s:0058 e:000057 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/command.rb:150
c:0009 p:0035 s:0051 e:000050 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/command.rb:67
c:0008 p:0015 s:0048 e:000047 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/command.rb:143
c:0007 p:0048 s:0042 e:000041 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/command.rb:63
c:0006 p:0038 s:0031 e:000030 TOP    /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/commands.rb:18 [FINISH]
c:0005 p:---- s:0026 e:000025 CFUNC  :require
c:0004 p:0030 s:0021 e:000020 BLOCK  /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74
c:0003 p:0131 s:0015 e:000014 METHOD /home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_requir
c:0002 p:0024 s:0006 e:000005 EVAL   bin/rails:4 [FINISH]
c:0001 p:0000 s:0003 E:0003e0 DUMMY  [FINISH]

-- Ruby level backtrace information ----------------------------------------
bin/rails:4:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/commands.rb:18:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/command.rb:63:in `invoke'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/command.rb:143:in `with_argv'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/command.rb:67:in `block in invoke'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/command.rb:150:in `invoke_rake'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/commands/rake/rake_command.rb:20:in `perform'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/commands/rake/rake_command.rb:41:in `with_rake'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_module.rb:59:in `with_application'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/commands/rake/rake_command.rb:43:in `block in with_rake'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:125:in `load_rakefile'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:214:in `standard_exception_handling'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:126:in `block in load_rakefile'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:740:in `raw_load_rakefile'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_module.rb:29:in `load_rakefile'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_module.rb:29:in `load'
/workspaces/foobar/rakefile:4:in `<main>'
/workspaces/foobar/rakefile:4:in `require_relative'
/workspaces/foobar/config/application.rb:3:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/all.rb:3:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails.rb:13:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/railties-8.0.2/lib/rails/application.rb:9:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/encrypted_configuration.rb:4:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/encrypted_file.rb:5:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/message_encryptor.rb:6:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/messages/codec.rb:4:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/messages/codec.rb:4:in `require_relative'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/messages/metadata.rb:4:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/json.rb:4:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/json/encoding.rb:3:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/core_ext/object/json.rb:14:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/core_ext/time/conversions.rb:5:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/values/time_zone.rb:3:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/tzinfo-2.0.6/lib/tzinfo.rb:25:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/tzinfo-2.0.6/lib/tzinfo.rb:25:in `require_relative'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/tzinfo-2.0.6/lib/tzinfo/string_deduper.rb:4:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent.rb:6:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomics.rb:8:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomic/reentrant_read_write_lock.rb:7:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomic/lock_local_var.rb:5:in `<main>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomic/lock_local_var.rb:18:in `<module:Concurrent>'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomic/lock_local_var.rb:12:in `mutex_owned_per_thread?'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomic/lock_local_var.rb:12:in `synchronize'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomic/lock_local_var.rb:14:in `block in mutex_owned_per_thread?'
/home/vscode/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/atomic/lock_local_var.rb:14:in `resume'

-- Threading information ---------------------------------------------------
Total ractor count: 1
Ruby thread count for this ractor: 1

-- Machine register context ------------------------------------------------
  x0: 0x0000aaaae61af9f0  x1: 0x0000aaaae73e4b80  x2: 0x0000ffffec601ba0
  x3: 0x0000ffff7821ff60  x4: 0x0000ffff78220018  x5: 0x0000ffff78240000
  x6: 0x0000ffff9318bb90  x7: 0x0000000000000000 x18: 0x0000000000000000
 x19: 0x0000000000000000 x20: 0x0000000000000000 x21: 0x0000000000000000
 x22: 0x0000000000000000 x23: 0x0000000000000000 x24: 0x0000000000000000
 x25: 0x0000000000000000 x26: 0x0000000000000000 x27: 0x0000000000000000
 x28: 0x0000000000000000 x29: 0x0000000000000000  sp: 0x0000ffff78220000
 fau: 0x0079ffff92ade6c0

-- C level backtrace information -------------------------------------------
bin/setup:7:in `system': Command failed with SIGSEGV (signal 11): bin/rails (RuntimeError)
        from bin/setup:7:in `system!'
        from bin/setup:24:in `block in <main>'
        from /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/fileutils.rb:240:in `chdir'
        from /home/vscode/.rbenv/versions/3.3.0/lib/ruby/3.3.0/fileutils.rb:240:in `cd'
        from bin/setup:10:in `<main>'
```